### PR TITLE
Added total traffic calculation

### DIFF
--- a/core/scripts/hysteria2/server_info.sh
+++ b/core/scripts/hysteria2/server_info.sh
@@ -65,6 +65,10 @@ if [ -f "$USERS_FILE" ]; then
     total_download_human=$(convert_bytes $total_download)
 
     echo "🔼${total_upload_human} uploaded"
-    
     echo "🔽${total_download_human} downloaded"
+    
+    # Add total traffic calculation
+    total_traffic=$((total_upload + total_download))
+    total_traffic_human=$(convert_bytes $total_traffic)
+    echo "📊 ${total_traffic_human} total traffic"
 fi

--- a/core/scripts/hysteria2/server_info.sh
+++ b/core/scripts/hysteria2/server_info.sh
@@ -67,7 +67,6 @@ if [ -f "$USERS_FILE" ]; then
     echo "🔼${total_upload_human} uploaded"
     echo "🔽${total_download_human} downloaded"
     
-    # Add total traffic calculation
     total_traffic=$((total_upload + total_download))
     total_traffic_human=$(convert_bytes $total_traffic)
     echo "📊 ${total_traffic_human} total traffic"


### PR DESCRIPTION
Added a new feature to display the total combined traffic (upload + download) in the server information output. This makes it easier for administrators to see the total traffic handled by the server without manual calculation.

## Changes
- Added total traffic calculation to server_info.sh
- Uses existing convert_bytes function for consistent formatting
