### PR TITLE
Fix:  Restored user edit functionality after traffic display format change

### DIFF
--- a/core/scripts/webpanel/templates/users.html
+++ b/core/scripts/webpanel/templates/users.html
@@ -311,10 +311,10 @@
                         showRow = $(this).find("td:eq(1) i").hasClass("text-danger");
                         break;
                     case "enable":
-                        showRow = $(this).find("td:eq(7) i").hasClass("text-success");
+                        showRow = $(this).find("td:eq(6) i").hasClass("text-success");
                         break;
                     case "disable":
-                        showRow = $(this).find("td:eq(7) i").hasClass("text-danger");
+                        showRow = $(this).find("td:eq(6) i").hasClass("text-danger");
                         break;
                 }
 
@@ -456,14 +456,14 @@
         $(document).on("click", ".edit-user", function () {
             const username = $(this).data("user");
             const row = $(this).closest("tr");
-            const quota = row.find("td:eq(3)").text().trim();
-            const expiry = row.find("td:eq(5)").text().trim(); // Get expiry from the table
-            const expiry_days = row.find("td:eq(6)").text().trim();
-            const blocked = row.find("td:eq(7)").text().trim().toLowerCase() === 'disabled'; // Check if 'disabled'
+            const quota = row.find("td:eq(3)").text().trim(); // Now refers to Traffic Usage
+            const expiry = row.find("td:eq(4)").text().trim(); // Now expiry date is at index 4
+            const expiry_days = row.find("td:eq(5)").text().trim(); // Now expiry days is at index 5
+            const blocked = row.find("td:eq(6) i").hasClass("text-danger"); // Now Enable column is at index 6
 
-            // Extract numeric values from quota and expiry strings
-            const quotaValue = parseFloat(quota);
-            const expiryValue = parseInt(expiry); // Parse expiry as integer
+            // Extract quota value from the combined format like "1.25 GB/10.00 GB (12.5%)"
+            const quotaMatch = quota.match(/\/\s*([\d.]+)/);
+            const quotaValue = quotaMatch ? parseFloat(quotaMatch[1]) : 0;
 
             // Populate the modal fields
             $("#originalUsername").val(username);


### PR DESCRIPTION
##Issue Description
The root cause was that the column indices in the JavaScript code were not properly updated after removing the "Quota" column.

##Changes Made

Updated filter buttons to correctly target the "Enable" column at index 6 (previously 7)
Fixed edit user form to extract data from the correct columns after the index shift
Enhanced user blocking detection

##Testing
The following functionality has been verified working correctly:

Filtering users by status
Editing user details (username, quota, expiration, reset, deletion)
Enabling/disabling users
Displaying the proper traffic usage format
These changes restore full functionality to the user management interface while maintaining the improved traffic display format with percentages.

##Fixes issues introduced by the changes made in PR #123 (implementation of #117)