### PR TITLE
Add default_domain_resolver support for Sing-box 1.14

### DIFF
--- a/core/scripts/normalsub/singbox.json
+++ b/core/scripts/normalsub/singbox.json
@@ -91,6 +91,9 @@
   "route": {
     "auto_detect_interface": true,
     "final": "proxy",
+    "default_domain_resolver": {
+      "server": "local-dns"
+    },
     "rule_set": [
       {
         "download_detour": "direct",


### PR DESCRIPTION
This update adds support for a newly introduced field in the Sing-box JSON configuration, ensuring forward compatibility with the changes planned for Sing-box v1.14.

*Testing Summary:
Successfully loaded in the Sing-box Android application with no warnings or errors.
DNS routing functionality confirmed to operate as expected.