### PR TITLE
Added 1000 users per page option to webpanel user list

### DIFF
--- a/core/scripts/webpanel/templates/users.html
+++ b/core/scripts/webpanel/templates/users.html
@@ -162,6 +162,7 @@
                                         <option value="25">25</option>
                                         <option value="50" selected>50</option>
                                         <option value="100">100</option>
+                                        <option value="1000">1000</option>
                                     </select>
                                 </form>
                             </div>


### PR DESCRIPTION
 Benefits
- Allows administrators to view up to 1000 users on a single page
- Reduces pagination overhead for large user bases

Testing
- Verified pagination logic works correctly with the new limit
